### PR TITLE
add documentation for :uberjar-name setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Add this to your plugins section in your project.clj
 [camechis/deploy-uberjar "0.2.0"]
 ```
 
+Set uberjar-name 
+```
+:uberjar-name "your-standalone.jar"
+```
+
 The following will deploy the uberjar to the release repository
 
 ```


### PR DESCRIPTION
Looks like  this plugin relies on  :uberjar-name to be present, added documentation for it. It's possible to infer the standalone jar file name if one is not specified. I'd be happy to fix it but i'm not a clojure expert and can't invest whole lot of time in fixing that part as i have other commitments. 

I am happy to create an issue if you like. I could possibly contribute in future if/when i learn enough project. 
