### PR TITLE
Match versions in uberjar filename

### DIFF
--- a/src/leiningen/deploy_uberjar.clj
+++ b/src/leiningen/deploy_uberjar.clj
@@ -22,7 +22,8 @@
   (format "%s/%s" (:group project) (:name project)))
 
 (defn get-uberjar-path [project]
-  (format "%s/%s" (:target-path project)(:uberjar-name project)))
+  (format (format "%s/%s" (:target-path project)(:uberjar-name project))
+          (:version project)))
 
 (defn uberjar? [uberjar]
   (.exists (io/as-file uberjar)))


### PR DESCRIPTION
Leiningen allows :uberjar to template the version with "%s".

Matching uberjar file names should also follow this.